### PR TITLE
Wrap export mailer in Sidekiq job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,4 +31,5 @@ group :development, :test do
   gem "pry"
   gem "pry-byebug"
   gem "pry-rails"
+  gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.19.4)
     thread_safe (0.3.6)
+    timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     websocket-driver (0.6.4)
@@ -225,6 +226,7 @@ DEPENDENCIES
   sidekiq
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
 
 RUBY VERSION
    ruby 2.3.0p0

--- a/app/jobs/export_bills_job.rb
+++ b/app/jobs/export_bills_job.rb
@@ -1,0 +1,7 @@
+class ExportBillsJob
+  include Sidekiq::Worker
+
+  def perform
+    BillsMailer.weekly_export_email.deliver_later if Time.now.saturday?
+  end
+end

--- a/app/services/bills_csv_service.rb
+++ b/app/services/bills_csv_service.rb
@@ -8,19 +8,6 @@ class BillsCsvService
     end
   end
 
-  def build_bills_query(start_date = default_start_date)
-    query = Bill.includes(hearing: :committee)
-      .references(:hearings)
-      .where("hearings.date >= ?", start_date)
-      .order("hearings.date ASC")
-
-    query
-  end
-
-  def default_start_date
-    Time.now.beginning_of_week(:sunday)
-  end
-
   private
 
   def columns

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -1,13 +1,17 @@
 namespace :jobs do
   desc "Enqueues import job"
   task :"import-hearings" => :environment do
-    Chamber.all.each do |chamber|
+    puts "○ job:import-hearings - starting import jobs..."
+    job_ids = Chamber.map.each do |chamber|
       ImportHearingsJob.perform_async(chamber.id)
     end
+    puts "✔ job:import-hearings - started jobs: #{job_ids}"
   end
 
   desc "Enqueues export job"
   task :"export-bills" => :environment do
-    BillsMailer.weekly_export_email.deliver_later
+    puts "○ job:export-bills - starting export-job..."
+    job_id = ExportBillsJob.perform_async
+    puts "✔ job:export-bills - started export-job: #{job_id}"
   end
 end

--- a/spec/jobs/export_bills_job_spec.rb
+++ b/spec/jobs/export_bills_job_spec.rb
@@ -1,0 +1,41 @@
+describe ExportBillsJob do
+  subject { described_class.new }
+
+  describe "#perform" do
+    let(:mailer) { double("weekly_export_email") }
+
+    before do
+      allow(BillsMailer).to receive(:weekly_export_email).and_return(mailer)
+      allow(mailer).to receive(:deliver_later)
+    end
+
+    context "when it's saturday" do
+      let(:date) { Time.now.sunday - 1.days }
+      let(:start_date) { date.beginning_of_week(:sunday) }
+
+      before do
+        Timecop.freeze(date)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "sends the export mailer" do
+        subject.perform
+        expect(mailer).to have_received(:deliver_later)
+      end
+    end
+
+    context "when it is not saturday" do
+      before do
+        allow(Time).to receive(:now).and_return(Time.now.monday)
+      end
+
+      it "does not send the mailer" do
+        subject.perform
+        expect(mailer).to_not have_received(:deliver_later)
+      end
+    end
+  end
+end

--- a/spec/mailers/bills_mailer_spec.rb
+++ b/spec/mailers/bills_mailer_spec.rb
@@ -2,22 +2,27 @@ describe BillsMailer, type: :mailer do
   subject { described_class }
 
   describe "#weekly_export_email" do
-    let(:service) { double("csv-service") }
+    let(:date) { Time.new(1995, 5, 3) }
+    let(:start_date) { date.beginning_of_week(:sunday) }
+    let(:recipients) { "  one@test.com ,  two@test.com" }
     let(:csv) { Faker::Lorem.sentence }
-    let(:start_date) { Time.new(1995, 5, 1) }
+    let(:service) { double("csv-service") }
     let(:mail) { subject.weekly_export_email(service).deliver_now }
-    let(:env_recipients) { "  one@test.com ,  two@test.com" }
 
     before do
       allow(service).to receive(:serialize).and_return(csv)
-      allow(service).to receive(:default_start_date).and_return(start_date)
-
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("EXPORT_MAILER_RECIPIENTS").and_return(env_recipients)
+      allow(ENV).to receive(:[]).with("EXPORT_MAILER_RECIPIENTS").and_return(recipients)
+
+      Timecop.freeze(date)
+    end
+
+    after do
+      Timecop.return
     end
 
     it "sets the subject" do
-      expect(mail.subject).to eq("Bills for Hearings 95.05.01-95.05.08")
+      expect(mail.subject).to eq("Bills for Hearings 95.04.30-95.05.07")
     end
 
     it "sets the sender" do
@@ -29,15 +34,26 @@ describe BillsMailer, type: :mailer do
     end
 
     it "populates the body" do
-      expect(mail.body.encoded).to match("95.05.01")
+      expect(mail.body.encoded).to match("95.04.30")
     end
 
     it "attaches the csv" do
       attachment = mail.attachments[0]
       expect(attachment).to be_present
-      expect(attachment.filename).to eq("il-bills-95.05.01-95.05.08.csv")
-      expect(attachment.mime_type).to eq("text/csv")
+      expect(attachment.filename).to eq("il-bills-95.04.30-95.05.07.csv")
+      expect(attachment.mime_type).to eq("text/csv" )
       expect(attachment.body.decoded).to eq(csv)
+    end
+
+    context "serializes a csv that" do
+      let!(:bill1) { create(:bill, hearing: create(:hearing, :with_any_committee, date: start_date - 1.days)) }
+      let!(:bill3) { create(:bill, hearing: create(:hearing, :with_any_committee, date: start_date + 1.days)) }
+      let!(:bill2) { create(:bill, hearing: create(:hearing, :with_any_committee, date: start_date)) }
+
+      it "contains bills from the most recent week" do
+        subject.weekly_export_email(service).deliver_now
+        expect(service).to have_received(:serialize).with([bill2, bill3])
+      end
     end
   end
 end

--- a/spec/services/bills_csv_service_spec.rb
+++ b/spec/services/bills_csv_service_spec.rb
@@ -42,22 +42,4 @@ describe BillsCsvService do
       expect(rows.drop(1)).to eq(bill_rows)
     end
   end
-
-  describe "#build_bills_query" do
-    let!(:date) { bill1.hearing.date + 1.days }
-    let!(:bill1) { create(:bill, :with_any_hearing) }
-    let!(:bill3) { create(:bill, hearing: create(:hearing, :with_any_committee, date: date + 1.days)) }
-    let!(:bill2) { create(:bill, hearing: create(:hearing, :with_any_committee, date: date)) }
-
-    it "only includes bills after or on the datetime" do
-      bills = subject.build_bills_query(date).to_a
-      expect(bills).to eq([bill2, bill3])
-    end
-  end
-
-  describe "#default_start_date" do
-    it "is last sunday" do
-      expect(subject.default_start_date).to eq(Time.now.beginning_of_week(:sunday))
-    end
-  end
 end


### PR DESCRIPTION
Heroku Scheduler's least granular timeframe is daily, so we need a wrapper job to fire the mailer only on the correct day. Eventually, we should integrate some kind of workflow tool / roll something light so that the mailer goes out after after the import finishes.